### PR TITLE
Remove JSON.stringify method on testplan object in response

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ app.get('/testplan', function (req, res) {
     }
     testPlan.baseUrlIPv4 = global.AddressIpv4 + ':' + webPort;
     testPlan.port = webPort;
-    res.json(JSON.stringify(testPlan));
+    res.json(testPlan);
 });
 
 /**


### PR DESCRIPTION
Why: Response from testplan endpoint can not be parsed with JSON.parse in xmlhttprequest
How: remove JSON.stringify method on testplan object in response
Test: verify that JSON.parse on response in xmlhttprequest is object and not a string
