### PR TITLE
Adding latency based routing feature to core library

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,7 @@
   </table>
 </body>
 
+<script src='lib/latencyBasedRouting.js'></script>
 <script src="lib/calculateStats.js"></script>
 <script src="lib/xmlhttprequest.js"></script>
 <script src="lib/webSocket.js"></script>
@@ -47,7 +48,14 @@ xhr.onreadystatechange = function() {
 }
 xhr.open('GET', '/testplan', true);
 xhr.send(null);
-
+function callbackComplete(result) {
+  console.log(result);
+}
+function callbackError(result) {
+  console.log(result);
+}
+var latencyBasedRouting = new window.latencyBasedRouting('NJ', callbackComplete, callbackError);
+latencyBasedRouting.getNearestServer();
 ///latencyHttpTestSuite
 /*
 function latencyHttpOnComplete(result){
@@ -65,12 +73,10 @@ function latencyHttpOnTimeout(result){
 function latencyHttpOnError(result){
   console.dir(result);
 }
-
 var latencyHttpTestSuite = new window.latencyHttpTest('/latency', 10 ,30000, latencyHttpOnComplete, latencyHttpOnProgress,
 latencyHttpOnAbort, latencyHttpOnTimeout,latencyHttpOnError);
 latencyHttpTestSuite.start();
 */
-
 //latencyWebSocketTestSuite
 /*
 function latencyWebSocketOnComplete(result){
@@ -85,43 +91,38 @@ function latencyWebSocketOnError(result){
 var latencyWebSocketTest = new window.latencyWebSocketTest('ws://localhost:3001', 'GET', '0','10',3000,latencyWebSocketOnComplete,
 latencyWebSocketOnProgress,latencyWebSocketOnError);
 latencyWebSocketTest.start();
-
-
 */
-
 //downloadHttpConcurrent
-
-function calculateStatsonComplete(result) {
-  console.log(result);
-}
-
-function calculateStatsonError(result) {
-  console.log(result);
-}
-
-function downloadHttpOnComplete(result){
-  console.dir(result);
-  var calculateMeanStats = new window.calculateStats(result, calculateStatsonComplete, calculateStatsonError);
-  calculateMeanStats.performCalculations();
-}
-function downloadHttpOnProgress(result){
-  console.log(result);
-}
-function downloadHttpOnAbort(result){
-  //console.dir(result);
-}
-function downloadHttpOnTimeout(result){
-  console.dir(result);
-}
-function downloadHttpOnError(result){
-  console.dir(result);
-}
-
-var downloadHttpConcurrentTestSuite = new window.downloadHttpConcurrent('/download?bufferSize=10000000','GET', 4 ,15000, 10000,downloadHttpOnComplete, downloadHttpOnProgress,
-downloadHttpOnAbort,downloadHttpOnTimeout,downloadHttpOnError);
-downloadHttpConcurrentTestSuite.start();
-
-
+//
+// function calculateStatsonComplete(result) {
+//   console.log(result);
+// }
+//
+// function calculateStatsonError(result) {
+//   console.log(result);
+// }
+//
+// function downloadHttpOnComplete(result){
+//   console.dir(result);
+//   var calculateMeanStats = new window.calculateStats(result, calculateStatsonComplete, calculateStatsonError);
+//   calculateMeanStats.performCalculations();
+// }
+// function downloadHttpOnProgress(result){
+//   console.log(result);
+// }
+// function downloadHttpOnAbort(result){
+//   //console.dir(result);
+// }
+// function downloadHttpOnTimeout(result){
+//   console.dir(result);
+// }
+// function downloadHttpOnError(result){
+//   console.dir(result);
+// }
+//
+// var downloadHttpConcurrentTestSuite = new window.downloadHttpConcurrent('/download?bufferSize=10000000','GET', 4 ,15000, 10000,downloadHttpOnComplete, downloadHttpOnProgress,
+// downloadHttpOnAbort,downloadHttpOnTimeout,downloadHttpOnError);
+// downloadHttpConcurrentTestSuite.start();
 //uploadHttpConcurrent
 /*
 function uploadHttpOnComplete(result){
@@ -141,10 +142,8 @@ function uploadHttpOnTimeout(result){
 function uploadHttpOnError(result){
   console.dir(result);
 }
-
 var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrent('/upload','POST',2,15000,15000,uploadHttpOnComplete, uploadHttpOnProgress,
 uploadHttpOnError,500000);
 uploadHttpConcurrentTestSuite.start();
 */
-
 </script>

--- a/public/lib/latencyBasedRouting.js
+++ b/public/lib/latencyBasedRouting.js
@@ -1,0 +1,106 @@
+(function () {
+    'use strict';
+
+    /**
+     * latencyBasedRouting
+     * @param location - pass the location to get the list available servers
+     * @param callbackComplete - callback function for test suite complete event
+     * @param callbackError - callback function for test suite error event
+     */
+    function latencyBasedRouting(location, callbackComplete, callbackError) {
+        this.location = location;
+        this.clientCallbackComplete = callbackComplete;
+        this.clientCallbackError = callbackError;
+        // when running add server information to this array
+        this.testData = [];
+        this.latencyHttpTestRequest = [];
+        this.numServersResponded = 0;
+    }
+
+    /**
+     * onError method
+     * @param result
+     * @return error object
+     */
+    latencyBasedRouting.prototype.onError = function (result) {
+        this.clientCallbackError(result);
+    };
+
+    /**
+     * Function getNearestServer returns all the available servers in a particular location
+     */
+    latencyBasedRouting.prototype.getNearestServer = function () {
+        //TODO get the server information from a database
+        this.performLatencyBasedRouting(this.testData);
+    };
+
+    /**
+     * Wrapper that calls selectServer to run the httpLatencyTest and creates a serverData object
+     * tracking different server parameters.
+     * @param data object contains server the information
+     */
+    latencyBasedRouting.prototype.performLatencyBasedRouting = function (data) {
+        var serverInfo;
+        for (var i = 0; i < data.length; i++) {
+            serverInfo = data[i];
+            var serverData = {
+                'IPv4': serverInfo.IPv4Address,
+                'IPv6': serverInfo.IPv6Address,
+                'Fqdn': serverInfo.Fqdn,
+                'latencyResult': []
+            };
+            var url = 'http://' + serverInfo.IPv4Address + '/latencys';
+            this.selectServer(url, serverData);
+        }
+
+    };
+
+    /**
+     * Function selectServer performs the latency test against all the servers
+     * and retunrs the server information with lowest latency to the client
+     * @param url to perform latency test
+     * @param data which contains server information {IPv4Address, IPv6Address, Fqdn}
+     */
+    latencyBasedRouting.prototype.selectServer = function (url, data) {
+        var self = this;
+        //latencyHttpOnComplete
+        var latencyHttpOnComplete = function (result) {
+            self.numServersResponded++;
+            if (self.numServersResponded === 1) {
+                data.latencyResult.push(result[0].time);
+                self.clientCallbackComplete(data);
+                // once we get the response from at least one server we abort all
+                // other latency request for rest of the servers
+                for (var i = 0; i < self.latencyHttpTestRequest.length; i++) {
+                    self.latencyHttpTestRequest[i].abortAll();
+                }
+            }
+
+        };
+        // creating latencyHttpTestSuite object for each server
+        var latencyHttpTestSuite = new window.latencyHttpTest(url, 1, 10000, latencyHttpOnComplete, latencyHttpOnProgress,
+            latencyHttpOnAbort, latencyHttpOnTimeout, latencyHttpOnError);
+        latencyHttpTestSuite.start();
+        // pushing latencyHttpTestSuite for each server into an array
+        self.latencyHttpTestRequest.push(latencyHttpTestSuite);
+    };
+
+    function latencyHttpOnProgress(result) {
+        console.log(result);
+    }
+
+    function latencyHttpOnAbort(result) {
+        console.dir(result);
+    }
+
+    function latencyHttpOnTimeout(result) {
+        console.dir(result);
+    }
+
+    function latencyHttpOnError(result) {
+        console.dir(result);
+    }
+
+    window.latencyBasedRouting = latencyBasedRouting;
+
+})();


### PR DESCRIPTION
Why: 
The server data doesn't always provide a direct nearest server value. In some cases, it brings us to a region. In these scenarios, we're left to ping a few servers in the area. We choose the value with the lowest latency value. This is what we call latency based routing.

How: 
Added javascript file perform latency based routing

Steps to Test: 
1. Open developer tool bar
2. Click network tab. 

Success Criteria:
You should be able to see 2 network calls one is 'Secacus' and 'Memphis' Servers.

TODO:
Need to store the server information in a database. For now i have mocked the data.
