### PR TITLE
Fix Duplicate License References and add 'use strict' to example files

### DIFF
--- a/public/examples/download/downloadTest.js
+++ b/public/examples/download/downloadTest.js
@@ -17,6 +17,8 @@
  */
 
 (function () {
+    'use strict';
+    
     //setting the initialization method for download test suite
     var oldOnload = window.onload;
     window.onload = function () {

--- a/public/examples/latency/latencyTest.js
+++ b/public/examples/latency/latencyTest.js
@@ -16,26 +16,9 @@
  * /
  */
 
-
-/*
- * *
- *  Copyright 2014 Comcast Cable Communications Management, LLC
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- * /
- */
-
 (function () {
+    'use strict';
+
     //setting the initialization method for latency test suite
     var oldOnload = window.onload;
     window.onload = function () {
@@ -290,7 +273,7 @@
                                 testRunner.push(new window.latencyHttpTest(baseUrl, 10, 30000, callback('http', testVersion, onComplete), callback('http', testVersion, onProgress),
                                     callback(testProtocol, testVersion, onAbort), callback(testVersion, onTimeout), callback('http', testVersion, onError)));
                                 //start latencyHttpTest
-                            }else if (testProtocol === 'webSocket' && (checked[testVersion] && checked[testProtocol])) {
+                            } else if (testProtocol === 'webSocket' && (checked[testVersion] && checked[testProtocol])) {
                                 //create an instance of latencyWebSocketTest
                                 baseUrl = [testPlan['webSocketUrl' + testVersion], '/latency'].join('');
                                 testRunner.push(new window.latencyWebSocketTest(baseUrl, 'GET', '0', '10', 3000, callback('webSocket', testVersion, onComplete),

--- a/public/examples/upload/uploadTest.js
+++ b/public/examples/upload/uploadTest.js
@@ -16,25 +16,8 @@
  * /
  */
 
-/*
- * *
- *  Copyright 2014 Comcast Cable Communications Management, LLC
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- * /
- */
-
 (function () {
+    'use strict';
     //setting the initialization method for upload test suite
     var oldOnload = window.onload;
     window.onload = function () {


### PR DESCRIPTION
WHY:
Duplicate License Reference in Some Files:
License references should only show up once in code. In some files, this shows up multiple times.
The files will be adjusted so that they only have one reference. 

'Use Strict'
Adding strongly typing in javascript to avoid basic semantic errors. 'use strict' is used for this

How:
- Add 'use strict' at beginning of anonymous function wrapper
- Removed duplicate software license references for specific files
