### PR TITLE
Update xmlHttpRequest call with progress event

### DIFF
--- a/public/lib/latencyHttpTest.js
+++ b/public/lib/latencyHttpTest.js
@@ -22,7 +22,7 @@
    * Latency testing based on httpRequests
    **/
   function latencyHttpTest(url, iterations, timeout, callbackComplete, callbackProgress, callbackAbort,
-    callbackTimeout, callbackError) {
+                           callbackTimeout, callbackError) {
     this.url = url;
     this.iterations = iterations;
     this.timeout = timeout;
@@ -40,13 +40,14 @@
     this.clientCallbackError = callbackError;
 
   };
+
   /**
-  * Execute the request
-  */
+   * Execute the request
+   */
   latencyHttpTest.prototype.start = function () {
     var cachebuster = Date.now();
-    this._test = new window.xmlHttpRequest('GET', [this.url, '?', cachebuster].join(''), this.timeout, this.onTestComplete.bind(this),
-      this.onTestAbort.bind(this), this.onTestTimeout.bind(this), this.onTestError.bind(this));
+    this._test = new window.xmlHttpRequest('GET', [this.url, '?', cachebuster].join(''), this.timeout, this.onTestComplete.bind(this),this.onTestProgress.bind(this),
+        this.onTestAbort.bind(this), this.onTestTimeout.bind(this), this.onTestError.bind(this));
     this._testIndex++;
     this._test.start(0, this._testIndex);
     this._activeTests.push({
@@ -54,37 +55,47 @@
       testRun: this._testIndex
     });
   };
+
   /**
-  * onError method
-  * @return abort object
-  */
+   * onError method
+   * @return abort object
+   */
   latencyHttpTest.prototype.onTestError = function (result) {
     if(this._running){
       this.clientCallbackError(result);
     }
   };
+
   /**
-  * onAbort method
-  * @return abort object
-  */
+   * onAbort method
+   * @return abort object
+   */
   latencyHttpTest.prototype.onTestAbort = function (result) {
     if(this._running){
       this.clientCallbackAbort(result);
     }
   };
+
   /**
-  * onTimeout method
-  * @return abort object
-  */
+   * onTimeout method
+   * @return abort object
+   */
   latencyHttpTest.prototype.onTestTimeout = function (result) {
     if(this._running){
       this.clientCallbackTimeout(result);
     }
   };
+
   /**
-  * onComplete method
-  * @return array of latencies
-  */
+   * onProgress method
+   */
+  latencyHttpTest.prototype.onTestProgress = function(result){
+    //latency does not report onProgressEvents
+  };
+  /**
+   * onComplete method
+   * @return array of latencies
+   */
   latencyHttpTest.prototype.onTestComplete = function (result) {
     if(!this._running){
       return;
@@ -102,16 +113,16 @@
   };
 
   /**
-  * Cancel the test
-  */
-    latencyHttpTest.prototype.abortAll = function() {
-      this._running = false;
-      for(var i=0;i<this._activeTests.length;i++){
-        if (typeof(this._activeTests[i])!== 'undefined') {
-          this._activeTests[i].xhr._request.abort();
-        }
+   * Cancel the test
+   */
+  latencyHttpTest.prototype.abortAll = function() {
+    this._running = false;
+    for(var i=0;i<this._activeTests.length;i++){
+      if (typeof(this._activeTests[i])!== 'undefined') {
+        this._activeTests[i].xhr._request.abort();
       }
     }
+  }
 
 
   /**
@@ -128,3 +139,4 @@
 
   window.latencyHttpTest = latencyHttpTest;
 })();
+


### PR DESCRIPTION
Why: latencyHttpTest was not passing in onProgress event to xmlhttprequest causing xmlhttprequest to not see onError function
How: add onProgress event to xmlhttprequest call
Test: run latencyTestSuite
