### PR TITLE
Add config folder to distribution

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function (grunt) {
                         {src: 'index.js', dest: 'dist/'},
                         {src: 'package.json', dest: 'dist/'},
                         {src: 'node_modules/**', dest: 'dist/'},
+                        {src: 'config/**', dest: 'dist/'},
                     ]
                 }
 


### PR DESCRIPTION
Why: config folder needed for deployment
How: Update gruntfile.js to include config folder for distribution
Test: run grunt package and verify config folder is under dist folder
