### PR TITLE
Update probing for lowbandwidth and remove test variables

### DIFF
--- a/public/lib/downloadProbeTest.js
+++ b/public/lib/downloadProbeTest.js
@@ -69,7 +69,9 @@
    * @param abort object
    */
    downloadProbeTest.prototype.onTestAbort = function (result) {
-
+        if(this._running){
+            this.clientCallbackError(result);
+        }
    };
 
    /**
@@ -90,8 +92,8 @@
       xhr.onreadystatechange = function() {
           if (xhr.readyState == XMLHttpRequest.DONE) {
             var data = JSON.parse(xhr.responseText);
-            //console.dir(data);
             self.clientCallbackComplete(data);
+              this._running=false;
 
           }
       }

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -143,8 +143,6 @@
             if (xhr.readyState == XMLHttpRequest.DONE) {
                 var data = JSON.parse(xhr.responseText);
                 testPlan = data;
-                testPlan.hasIPv6=false;
-                testPlan.baseUrlIPv4='69.252.86.194';
                 if (testPlan.performLatencyRouting) {
                     latencyBasedRouting();
                 }
@@ -329,7 +327,8 @@
         }
 
         function downloadProbeTestOnError(result) {
-            console.dir(result);
+            //use default value for download testing
+            void (!(testPlan.hasIPv6 === 'IPv6') && setTimeout(function () { downloadTest(testPlan.hasIPv6 ? 'IPv6' : 'IPv4'); }, 500));
         }
         var downloadProbeTestRun = new window.downloadProbeTest('/download?bufferSize='+downloadSize, false, 3000,762939,downloadProbeTestOnComplete,
             downloadProbeTestOnError);


### PR DESCRIPTION
Why: SpeedTest should continue if probes does not return data with default data
How: Update probe to report to client not values obtained.. client should continue test with default value
Test: run app locally in chrome and select Good 3G as network throttle connection type