### PR TITLE
Update websockets to use one socket connection for latency test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/lib/latencyWebSocketTest.js
+++ b/public/lib/latencyWebSocketTest.js
@@ -61,7 +61,8 @@
     this._results.push(result);
     this.clientCallbackProgress(result);
     if (this._testIndex < this.iterations) {
-      this.start();
+      this._testIndex++;
+      this._test.sendMessage();
     }
     else {
       this.clientCallbackComplete(this._results);

--- a/public/lib/webSocket.js
+++ b/public/lib/webSocket.js
@@ -48,11 +48,25 @@ webSocket.prototype.start = function(){
    }
 };
 
-webSocket.prototype._handleOnOpen = function(){
+/**
+ * webSocket onOpen Event
+ */
+  webSocket.prototype._handleOnOpen = function(){
       var obj = { 'data': Date.now().toString(), 'flag': 'latency' };
       this._request.send(JSON.stringify(obj), { mask: true });
 };
 
+/**
+ * send message for current webSocket
+ */
+webSocket.prototype.sendMessage =function() {
+    var obj = { 'data': Date.now().toString(), 'flag': 'latency' };
+    this._request.send(JSON.stringify(obj), { mask: true });
+};
+
+/**
+ * webSocket onMessage received Event
+ */
 webSocket.prototype._handleOnMessage = function(event){
   var finaltime = Date.now() - parseInt(event.data);
   var result={};
@@ -61,12 +75,15 @@ webSocket.prototype._handleOnMessage = function(event){
   this.callbackOnMessage(result);
 
 };
+
 webSocket.prototype._handleOnError = function(event){
   this.callbackOnMessage(event);
 };
 
+/**
+ * close webSocket connection
+ */
 webSocket.prototype._handleOnClose = function(){
-
   this._request.close();
 };
 

--- a/public/lib/webSocket.js
+++ b/public/lib/webSocket.js
@@ -24,7 +24,7 @@
   * @param stirng url address for request
   * @param integer timeout timeout for request
   * @param function callback for onloaded function
-  * @param function callback for onprogress function
+  * @param function callback for onerror function
   */
   function webSocket(url, type, transferSize, callbackOnMessage, callbackOnError){
   this.url = url;
@@ -76,6 +76,9 @@ webSocket.prototype._handleOnMessage = function(event){
 
 };
 
+/**
+ * webSocket onMessage error Event
+*/
 webSocket.prototype._handleOnError = function(event){
   this.callbackOnError(event);
 };

--- a/public/lib/webSocket.js
+++ b/public/lib/webSocket.js
@@ -77,7 +77,7 @@ webSocket.prototype._handleOnMessage = function(event){
 };
 
 webSocket.prototype._handleOnError = function(event){
-  this.callbackOnMessage(event);
+  this.callbackOnError(event);
 };
 
 /**


### PR DESCRIPTION
Why: Latency testing with webSockets should use one webSocket connection
How: Update web socket latency testing to use one webSocket connection and send latency requests with connection
Test: Test web socket latency in the /examples/latency/latency.html page with chrome and open the network console and verify one webSocket connection was used.