### PR TITLE
Update movingAverage to report the values for connection above 1 gigabit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/upload/uploadApp.js
+++ b/public/examples/upload/uploadApp.js
@@ -218,7 +218,7 @@
             void (!(testPlan.hasIPv6 === 'IPv6') && setTimeout(function () { !firstRun && uploadTest(testPlan.hasIPv6 ? 'IPv6' : 'IPv4'); }, 500));
         }
 
-        var uploadProbeTestRun = new window.uploadProbeTest('http://' +testPlan.baseUrlIPv4 + '/upload', '/uploadProbe', false, 3000, 194872, uploadProbeTestOnComplete, uploadProbeTestOnError);
+        var uploadProbeTestRun = new window.uploadProbeTest('/upload', '/uploadProbe', false, 3000, 194872, uploadProbeTestOnComplete, uploadProbeTestOnError);
         uploadProbeTestRun.start();
     }
 

--- a/public/examples/upload/uploadApp.js
+++ b/public/examples/upload/uploadApp.js
@@ -345,7 +345,7 @@
         }
         var baseUrl = (version === 'IPv6') ? 'http://' + testPlan.baseUrlIPv6 : 'http://' + testPlan.baseUrlIPv4;
 
-        var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrentProgress(baseUrl + '/upload', 'POST', 1, 15000, 15000, uploadHttpOnComplete, uploadHttpOnProgress,
+        var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrentProgress(baseUrl + '/upload', 'POST', 1, 15000, 15000, 2, uploadHttpOnComplete, uploadHttpOnProgress,
             uploadHttpOnError, uploadSize);
         uploadHttpConcurrentTestSuite.initiateTest();
 

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -32,7 +32,7 @@
      * @param function callback function for test suite error event
      * @param integer uploadSize of the request
      */
-    function uploadHttpConcurrentProgress(url, type, concurrentRuns, timeout, testLength, callbackComplete, callbackProgress,
+    function uploadHttpConcurrentProgress(url, type, concurrentRuns, timeout, testLength, movingAverage, callbackComplete, callbackProgress,
                                           callbackError, uploadSize) {
         this.url = url;
         this.type = type;
@@ -44,7 +44,7 @@
         this.clientCallbackProgress = callbackProgress;
         this.clientCallbackError = callbackError;
 
-        this.movingAverage = 2;
+        this.movingAverage = movingAverage;
         //unique id or test
         this._testIndex = 0;
         //array holding all results

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -44,7 +44,7 @@
         this.clientCallbackProgress = callbackProgress;
         this.clientCallbackError = callbackError;
 
-        this.movingAverage = 10;
+        this.movingAverage = 2;
         //unique id or test
         this._testIndex = 0;
         //array holding all results

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -585,7 +585,7 @@
         }
         var baseUrl = (version === 'IPv6') ? 'http://' + testPlan.baseUrlIPv6 : 'http://' + testPlan.baseUrlIPv4;
 
-        var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrentProgress(baseUrl + '/upload', 'POST', 1, 15000, 15000, uploadHttpOnComplete, uploadHttpOnProgress,
+        var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrentProgress(baseUrl + '/upload', 'POST', 1, 15000, 15000, 2, uploadHttpOnComplete, uploadHttpOnProgress,
             uploadHttpOnError, uploadSize);
         uploadHttpConcurrentTestSuite.initiateTest();
 


### PR DESCRIPTION
Why: Currently we are doing movingAverage for 10 values for the uploads. As we are only using single connection it doesn't show the values in UI when we move higher up to 1 gig connection.
How: Change the movingAverage to 2 should report the values in the UI
