### PR TITLE
Add end of test check in onprogress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -153,6 +153,18 @@
         if (!this._running) {
             return;
         }
+
+        if ((Date.now() - this._beginTime) > this.testLength) {
+          if (this.finalResults && this.finalResults.length) {
+            this.abortAll();
+            this.clientCallbackComplete(this.finalResults);
+          } else {
+            this.abortAll();
+            this.clientCallbackError('no measurements obtained');
+          }
+          this._running=false;
+        }
+
         if(!this._collectMovingAverages){
             return;
         }

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -182,6 +182,18 @@
             return;
         }
 
+        if ((Date.now() - this._beginTime) > this.testLength) {
+          if (this._finalResults && this._finalResults.length) {
+            this.abortAll();
+            this.clientCallbackComplete(this._finalResults);
+          } else {
+            this.abortAll();
+            this.clientCallbackError('no measurements obtained');
+          }
+          this._running = false;
+        }
+
+
         if (!this._collectMovingAverages) {
             return;
         }


### PR DESCRIPTION
Why: Tests should complete with the time indicated in the constructor.
How: Add end of test time check in OnProgress event
Test: run test in chrome with console open to networking.. verify test ends with time limit set in constructor.