### PR TITLE
Update WebSocket close event and handle event.code 1006 for safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.7",
+  "version": "1.0.6",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/lib/latencyWebSocketTest.js
+++ b/public/lib/latencyWebSocketTest.js
@@ -66,7 +66,7 @@
     }
     else {
       this.clientCallbackComplete(this._results);
-      this._test._handleOnClose();
+      this._test.close();
     }
   };
 

--- a/public/lib/webSocket.js
+++ b/public/lib/webSocket.js
@@ -84,11 +84,20 @@ webSocket.prototype._handleOnError = function(event){
 };
 
 /**
- * close webSocket connection
+ * webSocket close Event
  */
 webSocket.prototype._handleOnClose = function(){
-  this._request.close();
+  if((event!==null)&&(event.code == 1006)){
+    this.callbackOnError('connection error');
+  }
 };
+
+/**
+ * close webSocket
+ */
+webSocket.prototype.close = function(){
+  this._request.close();
+  };
 
 
 window.webSocket = webSocket;


### PR DESCRIPTION
Why: safari does not fire onError when webSocket url can not be resolved.
How: update webSocket onclose to check for event.code and add client close method
Test: run latency locally for ipv6 and in safari verify onError is called