### PR TITLE
Added microsoft specific parameters and also ui updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/upload/uploadApp.js
+++ b/public/examples/upload/uploadApp.js
@@ -39,6 +39,9 @@
     var uploadTestLength = 20000;
     var uploadMovingAverage = 1;
     var defaultUploadSize = 25526506;
+    var uiMovingAverage = 10;
+    var microsoftUploadSize = 17526506;
+    var microsoftUiUploadMovingAverage = 2;
 
     function initTest() {
         function addEvent(el, ev, fn) {
@@ -211,7 +214,9 @@
 
     function uploadProbe() {
         function uploadProbeTestOnComplete(result) {
-            if (result) {
+            uploadSize = defaultUploadSize;
+
+            if (result && isMobile()) {
                 uploadSize = result;
             }
 
@@ -350,12 +355,13 @@
         }
         var baseUrl = (version === 'IPv6') ? 'http://' + testPlan.baseUrlIPv6 : 'http://' + testPlan.baseUrlIPv4;
 
-        if (!isMobile()) {
-            uploadSize = defaultUploadSize;
+        if(navigator.appVersion.indexOf("MSIE") != -1 || navigator.appVersion.indexOf("Trident") != -1 || navigator.appVersion.indexOf("Edge") != -1){
+            uploadSize = microsoftUploadSize;
+            uiMovingAverage = microsoftUiUploadMovingAverage;
         }
 
         var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrentProgress(baseUrl + '/upload', 'POST', uploadConcurrentRuns, uploadTimeout, uploadTestLength,
-            uploadMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress, uploadHttpOnError, uploadSize);
+            uploadMovingAverage, uiMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress, uploadHttpOnError, uploadSize);
         uploadHttpConcurrentTestSuite.initiateTest();
 
     }

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -32,7 +32,7 @@
      * @param function callback function for test suite error event
      * @param integer uploadSize of the request
      */
-    function uploadHttpConcurrentProgress(url, type, concurrentRuns, timeout, testLength, movingAverage, callbackComplete, callbackProgress,
+    function uploadHttpConcurrentProgress(url, type, concurrentRuns, timeout, testLength, movingAverage, uiMovingAverage, callbackComplete, callbackProgress,
                                           callbackError, uploadSize) {
         this.url = url;
         this.type = type;
@@ -46,7 +46,7 @@
 
         this.movingAverage = movingAverage;
         //movingAverage to display the values in the UI
-        this.uiMovingAverage = 10;
+        this.uiMovingAverage = uiMovingAverage;
         //unique id or test
         this._testIndex = 0;
         //array holding all results

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -40,6 +40,9 @@
     var uploadTestLength = 20000;
     var uploadMovingAverage = 1;
     var defaultUploadSize = 25526506;
+    var uiMovingAverage = 10;
+    var microsoftUploadSize = 17526506;
+    var microsoftUiUploadMovingAverage = 2;
 
     function initTest() {
         function addEvent(el, ev, fn) {
@@ -463,7 +466,9 @@
 
     function uploadProbe() {
         function uploadProbeTestOnComplete(result) {
-            if (result) {
+            uploadSize = defaultUploadSize;
+
+            if (result && isMobile()) {
                 uploadSize = result;
             }
 
@@ -593,12 +598,13 @@
         }
         var baseUrl = (version === 'IPv6') ? 'http://' + testPlan.baseUrlIPv6 : 'http://' + testPlan.baseUrlIPv4;
 
-        if (!isMobile()) {
-            uploadSize = defaultUploadSize;
+        if(navigator.appVersion.indexOf("MSIE") != -1 || navigator.appVersion.indexOf("Trident") != -1 || navigator.appVersion.indexOf("Edge") != -1){
+            uploadSize = microsoftUploadSize;
+            uiMovingAverage = microsoftUiUploadMovingAverage;
         }
 
-        var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrentProgress(baseUrl + '/upload', 'POST', uploadConcurrentRuns, uploadTimeout, uploadTestLength, uploadMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress,
-            uploadHttpOnError, uploadSize);
+        var uploadHttpConcurrentTestSuite = new window.uploadHttpConcurrentProgress(baseUrl + '/upload', 'POST', uploadConcurrentRuns, uploadTimeout, uploadTestLength,
+            uploadMovingAverage, uiMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress, uploadHttpOnError, uploadSize);
         uploadHttpConcurrentTestSuite.initiateTest();
 
     }


### PR DESCRIPTION
Why: Upload measurements are not captured in microsoft browsers IE 10, 11 and Edge due to payload size
How: Added microsoft specific parameters and reduced the payload size
Test: run upload test with microsoft browser 