### PR TITLE
Add monitor to check number of servers responded and add timeout for latency based routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/latency/latencyApp.js
+++ b/public/examples/latency/latencyApp.js
@@ -34,6 +34,7 @@
     var startTestButton;
     var firstRun = true;
     var testServerTimeout = 2000;
+    var latencyTimeout = 3000;
 
     function initTest() {
         function addEvent(el, ev, fn) {
@@ -165,7 +166,7 @@
 
     function latencyBasedRouting() {
         // pass in the client location instead of the hard coded value
-        var latencyBasedRouting = new window.latencyBasedRouting('NJ', '/testServer', testServerTimeout, latencyBasedRoutingOnComplete, latencyBasedRoutingOnError);
+        var latencyBasedRouting = new window.latencyBasedRouting('NJ', '/testServer', testServerTimeout, latencyTimeout, latencyBasedRoutingOnComplete, latencyBasedRoutingOnError);
         latencyBasedRouting.getNearestServer();
     }
 

--- a/public/examples/upload/uploadApp.js
+++ b/public/examples/upload/uploadApp.js
@@ -43,6 +43,7 @@
     var microsoftUploadSize = 17526506;
     var microsoftUiUploadMovingAverage = 2;
     var testServerTimeout = 2000;
+    var latencyTimeout = 3000;
 
     function initTest() {
         function addEvent(el, ev, fn) {
@@ -174,7 +175,7 @@
 
     function latencyBasedRouting() {
         // pass in the client location instead of the hard coded value
-        var latencyBasedRouting = new window.latencyBasedRouting('NJ', '/testServer', testServerTimeout, latencyBasedRoutingOnComplete, latencyBasedRoutingOnError);
+        var latencyBasedRouting = new window.latencyBasedRouting('NJ', '/testServer', testServerTimeout, latencyTimeout, latencyBasedRoutingOnComplete, latencyBasedRoutingOnError);
         latencyBasedRouting.getNearestServer();
     }
 

--- a/public/lib/latencyBasedRouting.js
+++ b/public/lib/latencyBasedRouting.js
@@ -23,11 +23,12 @@
      * function performs latency based routing.
      * @param location - pass the location to get the list available servers.
      * @param url - end point for getting the server information.
-     * @param timeout - timeout for the test server request.
+     * @param testServerTimeout - timeout for the test server request.
+     * @param latencyTimeout - timeout for latency based routing.
      * @param callbackComplete - callback function for test suite complete event.
      * @param callbackError - callback function for test suite error event.
      */
-    function latencyBasedRouting(location, url, timeout, callbackComplete, callbackError) {
+    function latencyBasedRouting(location, url, testServerTimeout, latencyTimeout, callbackComplete, callbackError) {
         this.location = location;
         this.url = url;
         this.clientCallbackComplete = callbackComplete;
@@ -35,8 +36,8 @@
         this.latencyHttpTestRequest = [];
         this.numServersResponded = 0;
         this.trackingServerInfo = [];
-        this.testServerTimeout = timeout;
-        this.latencyBasedRoutingTimeout = 3000;
+        this.testServerTimeout = testServerTimeout;
+        this.latencyBasedRoutingTimeout = latencyTimeout;
     }
 
     /**
@@ -154,7 +155,12 @@
 
         if (Date.now() - this.beginTime > this.latencyBasedRoutingTimeout) {
             clearInterval(this.interval);
-            if (this.numServersResponded >= 1) {
+            if (this.trackingServerInfo && this.trackingServerInfo.length) {
+
+                this.trackingServerInfo = this.trackingServerInfo.sort(function (a, b) {
+                    return +a.latencyResult - +b.latencyResult;
+                });
+
                 this.clientCallbackComplete(this.trackingServerInfo[0]);
             } else {
                 this.clientCallbackError('no server available');

--- a/public/lib/latencyBasedRouting.js
+++ b/public/lib/latencyBasedRouting.js
@@ -20,10 +20,10 @@
     'use strict';
 
     /**
-     *
+     * function performs latency based routing.
      * @param location - pass the location to get the list available servers.
      * @param url - end point for getting the server information.
-     * @param timeout - timeout for the request.
+     * @param timeout - timeout for the test server request.
      * @param callbackComplete - callback function for test suite complete event.
      * @param callbackError - callback function for test suite error event.
      */
@@ -35,7 +35,8 @@
         this.latencyHttpTestRequest = [];
         this.numServersResponded = 0;
         this.trackingServerInfo = [];
-        this.latencyTimeout = timeout;
+        this.testServerTimeout = timeout;
+        this.latencyBasedRoutingTimeout = 3000;
     }
 
     /**
@@ -72,7 +73,7 @@
             }
         };
         var requestTimeout;
-        requestTimeout = setTimeout(request.abort.bind(request), this.latencyTimeout);
+        requestTimeout = setTimeout(request.abort.bind(request), this.testServerTimeout);
         request.abort = function () {
             self.clientCallbackError('no server information');
             clearTimeout(requestTimeout);
@@ -87,6 +88,11 @@
      * @param data object contains server the information
      */
     latencyBasedRouting.prototype.performLatencyBasedRouting = function (data) {
+        this.beginTime = Date.now();
+        var self = this;
+        this.interval = setInterval(function () {
+            self.monitor();
+        }, 100);
         var serverInfo;
         for (var i = 0; i < data.length; i++) {
             serverInfo = data[i];
@@ -99,7 +105,7 @@
                 'latencyResult': 0
             };
             var url = 'http://' + serverInfo.IPv4Address + '/latency';
-            this.selectServer(url, serverData);
+            self.selectServer(url, serverData);
         }
 
     };
@@ -121,6 +127,7 @@
             self.trackingServerInfo.push(data);
             self.numServersResponded++;
             if (self.numServersResponded === 3) {
+                clearInterval(self.interval);
                 // once we get the response from at least three server we abort all
                 // other latency request for rest of the servers
                 for (var i = 0; i < self.latencyHttpTestRequest.length; i++) {
@@ -141,6 +148,18 @@
         latencyHttpTestSuite.start();
         // pushing latencyHttpTestSuite for each server into an array
         self.latencyHttpTestRequest.push(latencyHttpTestSuite);
+    };
+
+    latencyBasedRouting.prototype.monitor = function () {
+
+        if (Date.now() - this.beginTime > this.latencyBasedRoutingTimeout) {
+            clearInterval(this.interval);
+            if (this.numServersResponded >= 1) {
+                this.clientCallbackComplete(this.trackingServerInfo[0]);
+            } else {
+                this.clientCallbackError('no server available');
+            }
+        }
     };
 
     function latencyHttpOnProgress() {

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -44,6 +44,7 @@
     var microsoftUploadSize = 17526506;
     var microsoftUiUploadMovingAverage = 2;
     var testServerTimeout = 2000;
+    var latencyTimeout = 3000;
 
     function initTest() {
         function addEvent(el, ev, fn) {
@@ -178,7 +179,7 @@
 
     function latencyBasedRouting() {
         // pass in the client location instead of the hard coded value
-        var latencyBasedRouting = new window.latencyBasedRouting('NJ', '/testServer', testServerTimeout, latencyBasedRoutingOnComplete, latencyBasedRoutingOnError);
+        var latencyBasedRouting = new window.latencyBasedRouting('NJ', '/testServer', testServerTimeout, latencyTimeout, latencyBasedRoutingOnComplete, latencyBasedRoutingOnError);
         latencyBasedRouting.getNearestServer();
     }
 


### PR DESCRIPTION
Adding monitor function to track the status of server responded for latency based routing. If latency based routing times out on every server then we should be able to continue the test on GSLB.