### PR TITLE
Add Validation On DownloadBuffer Size

### DIFF
--- a/controllers/DownloadController.js
+++ b/controllers/DownloadController.js
@@ -50,12 +50,17 @@ class DownloadController {
         res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
         res.header('Expires', '-1');
         res.header('Pragma', 'no-cache');
+      if(!isNaN(parseFloat(req.query.bufferSize)) && (parseFloat(req.query.bufferSize)<=532421875)){
         var bufferStream = new stream.PassThrough();
         bufferStream.pipe(res);
         var responseBuffer = new Buffer(parseInt(req.query.bufferSize));
         responseBuffer.fill(0x1020304);
         bufferStream.write(responseBuffer);
         bufferStream.end();
+      }
+      else{
+        res.status(404).end('bufferSize failed validation.');
+      }
     }
 }
 

--- a/controllers/DownloadController.js
+++ b/controllers/DownloadController.js
@@ -50,7 +50,7 @@ class DownloadController {
         res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
         res.header('Expires', '-1');
         res.header('Pragma', 'no-cache');
-      if(!isNaN(parseFloat(req.query.bufferSize)) && (parseFloat(req.query.bufferSize)<=532421875)){
+      if(!isNaN(parseInt(req.query.bufferSize)) && (isFinite(req.query.bufferSize)) && (parseInt(req.query.bufferSize)<=532421875)){
         var bufferStream = new stream.PassThrough();
         bufferStream.pipe(res);
         var responseBuffer = new Buffer(parseInt(req.query.bufferSize));

--- a/controllers/DownloadController.js
+++ b/controllers/DownloadController.js
@@ -50,7 +50,7 @@ class DownloadController {
         res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
         res.header('Expires', '-1');
         res.header('Pragma', 'no-cache');
-      if(!isNaN(parseInt(req.query.bufferSize)) && (isFinite(req.query.bufferSize)) && (parseInt(req.query.bufferSize)<=532421875)){
+      if(!isNaN(parseInt(req.query.bufferSize)) && (isFinite(req.query.bufferSize)) && (parseInt(req.query.bufferSize)<=global.maxDownloadBuffer) &&(parseInt(req.query.bufferSize)>0)){
         var bufferStream = new stream.PassThrough();
         bufferStream.pipe(res);
         var responseBuffer = new Buffer(parseInt(req.query.bufferSize));

--- a/controllers/DownloadController.js
+++ b/controllers/DownloadController.js
@@ -50,7 +50,7 @@ class DownloadController {
         res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
         res.header('Expires', '-1');
         res.header('Pragma', 'no-cache');
-      if(!isNaN(parseInt(req.query.bufferSize)) && (isFinite(req.query.bufferSize)) && (parseInt(req.query.bufferSize)<=global.maxDownloadBuffer) &&(parseInt(req.query.bufferSize)>0)){
+      if(!isNaN(parseInt(req.query.bufferSize))  && (parseInt(req.query.bufferSize)<=global.maxDownloadBuffer) &&(parseInt(req.query.bufferSize)>0)){
         var bufferStream = new stream.PassThrough();
         bufferStream.pipe(res);
         var responseBuffer = new Buffer(parseInt(req.query.bufferSize));

--- a/index.js
+++ b/index.js
@@ -89,6 +89,9 @@ module.exports.TestServerController = require('./controllers/TestServerControlle
 app.use(express.static(path.join(__dirname, 'public')));
 app.listen(webPort, '::');
 
+//max download buffer size based off of download probing data
+global.maxDownloadBuffer = 532421875;
+
 var wss = new WebSocketServer({port: webSocketPort});
 wss.on('connection', function connection(ws) {
     console.log('client connected');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/download/downloadApp.js
+++ b/public/examples/download/downloadApp.js
@@ -187,7 +187,7 @@
             //use default value for download testing
             void (!(testPlan.hasIPv6 === 'IPv6') && setTimeout(function () { downloadTest(testPlan.hasIPv6 ? 'IPv6' : 'IPv4'); }, 500));
         }
-        var downloadProbeTestRun = new window.downloadProbeTest('http://' + testPlan.baseUrlIPv4 +'/download?bufferSize='+downloadSize, 'http://' + testPlan.baseUrlIPv4 + '/downloadProbe', false, 3000,762939,downloadProbeTestOnComplete,
+        var downloadProbeTestRun = new window.downloadProbeTest('http://' + testPlan.baseUrlIPv4 +'/download', 'http://' + testPlan.baseUrlIPv4 + '/downloadProbe', false, 3000,downloadSize,downloadProbeTestOnComplete,
             downloadProbeTestOnError);
         downloadProbeTestRun.start();
 

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -335,7 +335,7 @@
             //use default value for download testing
             void (!(testPlan.hasIPv6 === 'IPv6') && setTimeout(function () { downloadTest(testPlan.hasIPv6 ? 'IPv6' : 'IPv4'); }, 500));
         }
-        var downloadProbeTestRun = new window.downloadProbeTest('http://' + testPlan.baseUrlIPv4 + '/download?bufferSize='+downloadSize, 'http://' + testPlan.baseUrlIPv4 + '/downloadProbe', false, 3000,762939,downloadProbeTestOnComplete,
+        var downloadProbeTestRun = new window.downloadProbeTest('http://' + testPlan.baseUrlIPv4 + '/download', 'http://' + testPlan.baseUrlIPv4 + '/downloadProbe', false, 3000,downloadSize,downloadProbeTestOnComplete,
             downloadProbeTestOnError);
         downloadProbeTestRun.start();
 


### PR DESCRIPTION
Why: download endpoints needs to return error for large buffer requests
How: add validation to endpoint to return 404 if buffer requests exceeds max value
Test: /download?bufferSize=532421875 is max value and should return binary 
/download?bufferSize=532421876 is over the max value and should return 404