### PR TITLE
iPad has thrown invalid state error  on xmlhttprequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/download/downloadApp.js
+++ b/public/examples/download/downloadApp.js
@@ -219,7 +219,7 @@
         function calculateStatsonComplete(result) {
             var finalValue = parseFloat(Math.round(result.stats.mean * 100) / 100).toFixed(2);
             finalValue = (finalValue > 1000) ? parseFloat(finalValue / 1000).toFixed(2) + ' Gbps' : finalValue + ' Mbps';
-            void ((version === 'IPv6') && uploadTest('IPv4'));
+            void ((version === 'IPv6') && downloadTest('IPv4'));
             if (!(version === 'IPv6')) {
                 //update dom with final result
                 startTestButton.disabled = false;

--- a/public/lib/xmlhttprequest.js
+++ b/public/lib/xmlhttprequest.js
@@ -166,13 +166,19 @@
               }
 
           }
-    if(this._request.status > 399){
-      var err = {
-        statusText: this._request.statusText,
-        status: this._request.status
-      };
-      this.callbackError(err);
-      return;
+    //mobile devices(iPad have thrown invalid state error for this check)
+    try {
+      if (this._request.status > 399) {
+        var err = {
+          statusText: this._request.statusText,
+          status: this._request.status
+        };
+        this.callbackError(err);
+        return;
+      }
+    }
+    catch(error){// jshint ignore:line
+
     }
   };
 


### PR DESCRIPTION
Why: documented iPad to have thrown invalid state error when checking status of xmlhttprequest on readystate change function
How: wrap status check in try to catch to capture condition
Test: run speedtest 10x and review logs to verify invalid state error not thrown