### PR TITLE
update latency to return results on abort error and timeout callbacks…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/latency/latencyApp.js
+++ b/public/examples/latency/latencyApp.js
@@ -231,72 +231,135 @@
         }
 
         function latencyHttpOnAbort(result) {
-            if (version === 'IPv6') {
-                testPlan.hasIPv6 = false;
-                latencyTest('IPv4');
-                return;
-            }
-                //set test value to 0
-                option.series[0].data[0].value = 0;
-                //updat test status to complete
-                option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
-                //This will also effect the visual look by corresponding css
-                startTestButton.setAttribute('aria-disabled', false);
-               //update button text to communicate current state of test as In Progress
-                startTestButton.innerHTML = 'Start Test';
-                //enable start button
-                startTestButton.disabled = false;
-                //hide current test value in chart 
-                option.series[0].detail.show = false;
-                //update gauge
-                myChart.setOption(option, true);
+          if(result.results.length===0) {
+            //set test value to 0
+            option.series[0].data[0].value = 0;
+            //updat test status to complete
+            option.series[0].data[0].name = 'Test Failed';
+            //set accessiblity aria-disabled state.
+            //This will also effect the visual look by corresponding css
+            startTestButton.setAttribute('aria-disabled', false);
+            //update button text to communicate current state of test as In Progress
+            startTestButton.innerHTML = 'Start Test';
+            //enable start button
+            startTestButton.disabled = false;
+            //hide current test value in chart
+            option.series[0].detail.show = false;
+            //update gauge
+            myChart.setOption(option, true);
+          }else{
+            result = result.results.sort(function (a, b) {
+              return +a.time - +b.time;
+            });
+            updateValue(currentTest, result[0].time + ' ms');
+          }
+          if (version === 'IPv6') {
+            latencyTest('IPv4');
+            return;
+          }
+          else{
+            void (!(version === 'IPv6') && setTimeout(function () {
+              //update button text to communicate current state of test as In Progress
+              startTestButton.innerHTML = 'Start Test';
+              option.series[0].data[0].value = 0;
+              option.series[0].data[0].name = 'Test Complete';
+              //set accessiblity aria-disabled state.
+              //This will also effect the visual look by corresponding css
+              startTestButton.setAttribute('aria-disabled', false);
+              startTestButton.disabled = false;
+              option.series[0].detail.show = false;
+              myChart.setOption(option, true);
+
+            }, 500));
+          }
         }
 
         function latencyHttpOnTimeout(result) {
-            if (version === 'IPv6') {
-                testPlan.hasIPv6 = false;
-                latencyTest('IPv4');
-                return;
-            }
-                //set test value to 0
-                option.series[0].data[0].value = 0;
-                //updat test status to complete
-                option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
-                //This will also effect the visual look by corresponding css
-                startTestButton.setAttribute('aria-disabled', false);
-               //update button text to communicate current state of test as In Progress
-                startTestButton.innerHTML = 'Start Test';
-                //enable start button
-                startTestButton.disabled = false;
-                //hide current test value in chart 
-                option.series[0].detail.show = false;
-                //update gauge
-                myChart.setOption(option, true);
+          if(result.results.length===0) {
+            //set test value to 0
+            option.series[0].data[0].value = 0;
+            //updat test status to complete
+            option.series[0].data[0].name = 'Test Failed';
+            //set accessiblity aria-disabled state.
+            //This will also effect the visual look by corresponding css
+            startTestButton.setAttribute('aria-disabled', false);
+            //update button text to communicate current state of test as In Progress
+            startTestButton.innerHTML = 'Start Test';
+            //enable start button
+            startTestButton.disabled = false;
+            //hide current test value in chart
+            option.series[0].detail.show = false;
+            //update gauge
+            myChart.setOption(option, true);
+          }else{
+            result = result.results.sort(function (a, b) {
+              return +a.time - +b.time;
+            });
+            updateValue(currentTest, result[0].time + ' ms');
+          }
+          if (version === 'IPv6') {
+            latencyTest('IPv4');
+            return;
+          }
+          else{
+            void (!(version === 'IPv6') && setTimeout(function () {
+              //update button text to communicate current state of test as In Progress
+              startTestButton.innerHTML = 'Start Test';
+              option.series[0].data[0].value = 0;
+              option.series[0].data[0].name = 'Test Complete';
+              //set accessiblity aria-disabled state.
+              //This will also effect the visual look by corresponding css
+              startTestButton.setAttribute('aria-disabled', false);
+              startTestButton.disabled = false;
+              option.series[0].detail.show = false;
+              myChart.setOption(option, true);
+
+            }, 500));
+          }
         }
 
         function latencyHttpOnError(result) {
-            if (version === 'IPv6') {
-                testPlan.hasIPv6 = false;
-                latencyTest('IPv4');
-                return;
-            }
-                //set test value to 0
-                option.series[0].data[0].value = 0;
-                //updat test status to complete
-                option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
-                //This will also effect the visual look by corresponding css
-                startTestButton.setAttribute('aria-disabled', false);
-               //update button text to communicate current state of test as In Progress
-                startTestButton.innerHTML = 'Start Test';
-                //enable start button
-                startTestButton.disabled = false;
-                //hide current test value in chart 
-                option.series[0].detail.show = false;
-                //update gauge
-                myChart.setOption(option, true);
+          if(result.results.length===0) {
+            //set test value to 0
+            option.series[0].data[0].value = 0;
+            //updat test status to complete
+            option.series[0].data[0].name = 'Test Failed';
+            //set accessiblity aria-disabled state.
+            //This will also effect the visual look by corresponding css
+            startTestButton.setAttribute('aria-disabled', false);
+            //update button text to communicate current state of test as In Progress
+            startTestButton.innerHTML = 'Start Test';
+            //enable start button
+            startTestButton.disabled = false;
+            //hide current test value in chart
+            option.series[0].detail.show = false;
+            //update gauge
+            myChart.setOption(option, true);
+          }else{
+            result = result.results.sort(function (a, b) {
+              return +a.time - +b.time;
+            });
+            updateValue(currentTest, result[0].time + ' ms');
+          }
+          if (version === 'IPv6') {
+            latencyTest('IPv4');
+            return;
+          }
+          else{
+            void (!(version === 'IPv6') && setTimeout(function () {
+              //update button text to communicate current state of test as In Progress
+              startTestButton.innerHTML = 'Start Test';
+              option.series[0].data[0].value = 0;
+              option.series[0].data[0].name = 'Test Complete';
+              //set accessiblity aria-disabled state.
+              //This will also effect the visual look by corresponding css
+              startTestButton.setAttribute('aria-disabled', false);
+              startTestButton.disabled = false;
+              option.series[0].detail.show = false;
+              myChart.setOption(option, true);
+
+            }, 500));
+          }
         }
 
         var baseUrl = (version === 'IPv6') ? 'http://' + testPlan.baseUrlIPv6 + '/latency' : 'http://' + testPlan.baseUrlIPv4 + '/latency';

--- a/public/examples/latency/latencyApp.js
+++ b/public/examples/latency/latencyApp.js
@@ -231,7 +231,7 @@
         }
 
         function latencyHttpOnAbort(result) {
-          if(result.results.length===0) {
+          if(result && result.results && result.results.length === 0) {
             //set test value to 0
             option.series[0].data[0].value = 0;
             //updat test status to complete
@@ -258,24 +258,24 @@
             return;
           }
           else{
-            void (!(version === 'IPv6') && setTimeout(function () {
-              //update button text to communicate current state of test as In Progress
-              startTestButton.innerHTML = 'Start Test';
-              option.series[0].data[0].value = 0;
-              option.series[0].data[0].name = 'Test Complete';
-              //set accessiblity aria-disabled state.
-              //This will also effect the visual look by corresponding css
-              startTestButton.setAttribute('aria-disabled', false);
-              startTestButton.disabled = false;
-              option.series[0].detail.show = false;
-              myChart.setOption(option, true);
+            if(!version === 'IPv6') {
+                //update button text to communicate current state of test as In Progress
+                startTestButton.innerHTML = 'Start Test';
+                option.series[0].data[0].value = 0;
+                option.series[0].data[0].name = 'Test Complete';
+                //set accessiblity aria-disabled state.
+                //This will also effect the visual look by corresponding css
+                startTestButton.setAttribute('aria-disabled', false);
+                startTestButton.disabled = false;
+                option.series[0].detail.show = false;
+                myChart.setOption(option, true);
+              }
 
-            }, 500));
           }
         }
 
         function latencyHttpOnTimeout(result) {
-          if(result.results.length===0) {
+          if(result && result.results && result.results.length === 0) {
             //set test value to 0
             option.series[0].data[0].value = 0;
             //updat test status to complete
@@ -302,7 +302,7 @@
             return;
           }
           else{
-            void (!(version === 'IPv6') && setTimeout(function () {
+            if(!version === 'IPv6'){
               //update button text to communicate current state of test as In Progress
               startTestButton.innerHTML = 'Start Test';
               option.series[0].data[0].value = 0;
@@ -314,12 +314,12 @@
               option.series[0].detail.show = false;
               myChart.setOption(option, true);
 
-            }, 500));
+            }
           }
         }
 
         function latencyHttpOnError(result) {
-          if(result.results.length===0) {
+          if(result && result.results && result.results.length === 0) {
             //set test value to 0
             option.series[0].data[0].value = 0;
             //updat test status to complete
@@ -346,7 +346,7 @@
             return;
           }
           else{
-            void (!(version === 'IPv6') && setTimeout(function () {
+            if(!version === 'IPv6'){
               //update button text to communicate current state of test as In Progress
               startTestButton.innerHTML = 'Start Test';
               option.series[0].data[0].value = 0;
@@ -358,7 +358,7 @@
               option.series[0].detail.show = false;
               myChart.setOption(option, true);
 
-            }, 500));
+            }
           }
         }
 

--- a/public/lib/latencyHttpTest.js
+++ b/public/lib/latencyHttpTest.js
@@ -45,7 +45,7 @@
    * Execute the request
    */
   latencyHttpTest.prototype.start = function () {
-    var cachebuster = Date.now();
+    var cachebuster = Math.random();
     this._test = new window.xmlHttpRequest('GET', [this.url, '?', cachebuster].join(''), this.timeout, this.onTestComplete.bind(this),this.onTestProgress.bind(this),
         this.onTestAbort.bind(this), this.onTestTimeout.bind(this), this.onTestError.bind(this));
     this._testIndex++;
@@ -62,7 +62,9 @@
    */
   latencyHttpTest.prototype.onTestError = function (result) {
     if(this._running){
+      result.results = this._results;
       this.clientCallbackError(result);
+      this._running = false;
     }
   };
 
@@ -72,7 +74,9 @@
    */
   latencyHttpTest.prototype.onTestAbort = function (result) {
     if(this._running){
+      result.results = this._results;
       this.clientCallbackAbort(result);
+      this._running = false;
     }
   };
 
@@ -82,7 +86,9 @@
    */
   latencyHttpTest.prototype.onTestTimeout = function (result) {
     if(this._running){
+      result.results = this._results;
       this.clientCallbackTimeout(result);
+      this._running = false;
     }
   };
 

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -252,7 +252,7 @@
         }
 
         function latencyHttpOnAbort(result) {
-            if(result.results.length===0) {
+            if(result && result.results && result.results.length === 0) {
                 //set test value to 0
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
@@ -281,7 +281,7 @@
         }
 
         function latencyHttpOnTimeout(result) {
-            if(result.results.length===0) {
+            if(result && result.results && result.results.length === 0) {
                 //set test value to 0
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
@@ -310,7 +310,7 @@
         }
 
         function latencyHttpOnError(result) {
-            if(result.results.length===0) {
+            if(result && result.results && result.results.length === 0) {
                 //set test value to 0
                 option.series[0].data[0].value = 0;
                 //updat test status to complete

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -252,72 +252,90 @@
         }
 
         function latencyHttpOnAbort(result) {
-            if (version === 'IPv6') {
-                testPlan.hasIPv6 = false;
-                latencyTest('IPv4');
-                return;
-            }
+            if(result.results.length===0) {
                 //set test value to 0
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
                 option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
-               //update button text to communicate current state of test as In Progress
+                //update button text to communicate current state of test as In Progress
                 startTestButton.innerHTML = 'Start Test';
                 //enable start button
                 startTestButton.disabled = false;
-                //hide current test value in chart 
+                //hide current test value in chart
                 option.series[0].detail.show = false;
                 //update gauge
                 myChart.setOption(option, true);
+            }else{
+                result = result.results.sort(function (a, b) {
+                    return +a.time - +b.time;
+                });
+                updateValue(currentTest, result[0].time + ' ms');
+            }
+            if (version === 'IPv6') {
+                latencyTest('IPv4');
+                return;
+            }
         }
 
         function latencyHttpOnTimeout(result) {
-            if (version === 'IPv6') {
-                testPlan.hasIPv6 = false;
-                latencyTest('IPv4');
-                return;
-            }
+            if(result.results.length===0) {
                 //set test value to 0
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
                 option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
-               //update button text to communicate current state of test as In Progress
+                //update button text to communicate current state of test as In Progress
                 startTestButton.innerHTML = 'Start Test';
                 //enable start button
                 startTestButton.disabled = false;
-                //hide current test value in chart 
+                //hide current test value in chart
                 option.series[0].detail.show = false;
                 //update gauge
                 myChart.setOption(option, true);
+            }else{
+                result = result.results.sort(function (a, b) {
+                    return +a.time - +b.time;
+                });
+                updateValue(currentTest, result[0].time + ' ms');
+            }
+            if (version === 'IPv6') {
+                latencyTest('IPv4');
+                return;
+            }
         }
 
         function latencyHttpOnError(result) {
-            if (version === 'IPv6') {
-                testPlan.hasIPv6 = false;
-                latencyTest('IPv4');
-                return;
-            }
+            if(result.results.length===0) {
                 //set test value to 0
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
                 option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
-               //update button text to communicate current state of test as In Progress
+                //update button text to communicate current state of test as In Progress
                 startTestButton.innerHTML = 'Start Test';
                 //enable start button
                 startTestButton.disabled = false;
-                //hide current test value in chart 
+                //hide current test value in chart
                 option.series[0].detail.show = false;
                 //update gauge
                 myChart.setOption(option, true);
+            }else{
+                result = result.results.sort(function (a, b) {
+                    return +a.time - +b.time;
+                });
+                updateValue(currentTest, result[0].time + ' ms');
+            }
+            if (version === 'IPv6') {
+                latencyTest('IPv4');
+                return;
+            }
         }
 
         var baseUrl = (version === 'IPv6') ? 'http://' + testPlan.baseUrlIPv6 + '/latency' : 'http://' + testPlan.baseUrlIPv4 + '/latency';


### PR DESCRIPTION
Why: if any issue occurs during latency testing we stop the entire speedtest
How: update latencyTest to return any existing results to in abort, error, timeout callbacks so client can check if any latency results were captured and continue with speedtest
Test: run locally in chrome and set throttle to have a high latency 200ms... insert the following code after line 48 in latencyHttpTest.js which will force a timeout abort and verify the test continues 
if(this._testIndex ===5){   this.timeout = 20; }