### PR TITLE
[US1114284] Move download calculations to client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/download/downloadApp.js
+++ b/public/examples/download/downloadApp.js
@@ -42,6 +42,8 @@
     var urls = [];
     var ports = [5020, 5021, 5022, 5023, 5024, 5025];
     var monitorInterval = 100;
+    var sliceStartValue = 0.3;
+    var sliceEndValue = 0.9;
 
     function initTest() {
         function addEvent(el, ev, fn) {
@@ -226,28 +228,9 @@
             updateValue([currentTest, '-', version].join(''), finalValue);
         }
 
-        function calculateStatsonError(result) {
-                //set test value to 0
-                option.series[0].data[0].value = 0;
-                //updat test status to complete
-                option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
-                //This will also effect the visual look by corresponding css
-                startTestButton.setAttribute('aria-disabled', false);
-               //update button text to communicate current state of test as In Progress
-                startTestButton.innerHTML = 'Start Test';
-                //enable start button
-                startTestButton.disabled = false;
-                //hide current test value in chart 
-                option.series[0].detail.show = false;
-                //update gauge
-                myChart.setOption(option, true);
-        }
-
         function downloadHttpOnComplete(result) {
-
-            var calculateMeanStats = new window.calculateStats('http://' + testPlan.baseUrlIPv4 + '/calculator', result, calculateStatsonComplete, calculateStatsonError);
-            calculateMeanStats.performCalculations();
+            var calculateMeanStats = new window.statisticalCalculator(result, false, sliceStartValue, sliceEndValue, calculateStatsonComplete);
+            calculateMeanStats.getResults();
         }
 
         function downloadHttpOnProgress(result) {

--- a/public/examples/download/index.html
+++ b/public/examples/download/index.html
@@ -60,7 +60,7 @@
 <script src="lib/downloadHttpConcurrentProgress.js"></script>
 <script src="lib/downloadProbeTest.js"></script>
 <script src="uilib/echarts.min.js"></script>
-
+<script src="lib/statisticalCalculator.js"></script>
 <script src="examples/download/downloadApp.js"></script>
 </body>
 

--- a/public/index.html
+++ b/public/index.html
@@ -83,6 +83,7 @@
 <script src="lib/uploadHttpConcurrent.js"></script>
 <script src="lib/uploadProbeTest.js"></script>
 <script src="lib/uploadHttpConcurrentProgress.js"></script>
+<script src="lib/statisticalCalculator.js"></script>
 <script src="uilib/echarts.min.js"></script>
 <script src="speed-testJS.js"></script>
 </body>

--- a/public/lib/statisticalCalculator.js
+++ b/public/lib/statisticalCalculator.js
@@ -1,0 +1,157 @@
+/*
+ * *
+ *  Copyright 2014 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+(function () {
+    'use strict';
+
+    /**
+     * Performs statistical calculations.
+     * @param data - array of values used for computation.
+     * @param iqrFilter - boolean to either perform iqrFiltering or slicing.
+     * @param start - slicing start value
+     * @param end - slicing end value.
+     * @param callbackComplete - callback function for test suite for complete event.
+     */
+    function statisticalCalculator(data, iqrFilter, start, end, callbackComplete) {
+        this.data = data;
+        this.isIqrFilter = iqrFilter;
+        //start is the value used for slicing the slowest data with given percentage.
+        this.start = start;
+        //end is the value used for slicing the fastest data with given percentage.
+        this.end = end;
+        this.clientCallbackComplete = callbackComplete;
+    }
+
+    /**
+     * This function is used to do the calculations either with IQRFiltering or go with Slicing
+     */
+    statisticalCalculator.prototype.getResults = function () {
+        this.data = this.data.sort(this.numericComparator);
+        var dataset = (this.isIqrFilter) ? this.interQuartileRange(data) : this.slicing(this.data, this.start, this.end);
+        var peakValue = dataset[dataset.length - 1];
+        var mean = this.meanCalculator(dataset);
+
+        var results = {
+            stats: mean,
+            peakValue: peakValue
+        };
+        this.clientCallbackComplete(results);
+    };
+
+    /**
+     * Calculate the interquartile range of an array of data points
+     *
+     * https://en.wikipedia.org/wiki/Interquartile_range
+     * In descriptive statistics, the interquartile range (IQR), also called
+     * the midspread or middle fifty, or technically H-spread, is a measure of
+     * statistical dispersion, being equal to the difference between the upper and
+     * lower quartiles,[1][2] IQR = Q3 âˆ’  Q1. In other words, the IQR is the 1st quartile subtracted from the 3rd quartile
+     * The interquartile range is often used to find outliers in data. Outliers are observations
+     * that fall below Q1 - 1.5(IQR) or above Q3 + 1.5(IQR)
+     */
+    statisticalCalculator.prototype.interQuartileRange = function (a) {
+        var length = a.length,
+            dataSetWithOutliersRemoved = [],
+            isEven = (a.length) % 2,
+            iqr,
+            i,
+            fQMedian,
+            tQMedian,
+            n;
+
+        if (isEven === 0) {
+            n = a.length;
+            fQMedian = this.medianCalculator(a.slice(0, (a.length) / 2));
+            tQMedian = this.medianCalculator(a.slice((a.length) / 2, n));
+            iqr = tQMedian - fQMedian;
+
+        } else {
+            n = a.length - 1;
+            a.splice((n / 2), 1);
+
+            fQMedian = this.medianCalculator(a.slice(0, (a.length) / 2));
+            tQMedian = this.medianCalculator(a.slice(((a.length) / 2) + 1, n + 1));
+            iqr = tQMedian - fQMedian;
+        }
+        var lowerOutliers = fQMedian - (1.5 * iqr);
+        var upperOutliers = tQMedian + (1.5 * iqr);
+
+        for (i = 0; i < length; i++) {
+
+            if (a[i] > lowerOutliers && a[i] < upperOutliers) {
+                dataSetWithOutliersRemoved.push(a[i]);
+            }
+        }
+
+        return dataSetWithOutliersRemoved;
+    };
+
+    /**
+     * Simple JavaScript comparator to help with sorting.
+     * @param a
+     * @param b
+     * @returns {number}
+     * @constructor
+     */
+    statisticalCalculator.prototype.numericComparator = function (a, b) {
+        return (a - b);
+    };
+
+    /**
+     * Calculates the Median.
+     * @param a
+     * @returns {number}
+     */
+    statisticalCalculator.prototype.medianCalculator = function (a) {
+        var n = a.length - 1;
+        var median = ((a[Math.floor(n / 2)] + a[Math.ceil(n / 2)]) / 2);
+        return median;
+    };
+
+    /**
+     * Calculates the sum and mean of an array
+     * @param arr
+     * @returns {{sum: *, mean: number}}
+     */
+    statisticalCalculator.prototype.meanCalculator = function (arr) {
+        var sum = arr.reduce(function (a, b) {
+            return a + b;
+        }, 0);
+        var mean = sum / arr.length;
+        return {
+            sum: sum,
+            mean: mean
+        };
+    };
+
+    /**
+     * Function takes in array slices the top 30% and bottom 10% of data
+     * @param a
+     * @returns {*}
+     */
+    statisticalCalculator.prototype.slicing = function (a, start, end) {
+        var dataLength = a.length;
+        var start = Math.round(dataLength * start);
+        var end = Math.round(dataLength * end);
+        var sliceData = a.slice(start, end);
+        return sliceData;
+    };
+
+    window.statisticalCalculator = statisticalCalculator;
+
+})();

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -52,6 +52,8 @@
   var uploadUrls = [];
   var uploadMonitorInterval = 200;
   var isMicrosoftBrowser = false;
+  var sliceStartValue = 0.3;
+  var sliceEndValue = 0.9;
 
   function initTest() {
     function addEvent(el, ev, fn) {
@@ -368,28 +370,10 @@
       updateValue([currentTest, '-', version].join(''), finalValue);
     }
 
-    function calculateStatsonError(result) {
-      //set test value to 0
-      option.series[0].data[0].value = 0;
-      //updat test status to complete
-      option.series[0].data[0].name = 'Test Failed';
-      //set accessiblity aria-disabled state.
-      //This will also effect the visual look by corresponding css
-      startTestButton.setAttribute('aria-disabled', false);
-      //update button text to communicate current state of test as In Progress
-      startTestButton.innerHTML = 'Start Test';
-      //enable start button
-      startTestButton.disabled = false;
-      //hide current test value in chart
-      option.series[0].detail.show = false;
-      //update gauge
-      myChart.setOption(option, true);
-    }
-
     function downloadHttpOnComplete(result) {
 
-      var calculateMeanStats = new window.calculateStats('http://' + testPlan.baseUrlIPv4 + '/calculator', result, calculateStatsonComplete, calculateStatsonError);
-      calculateMeanStats.performCalculations();
+        var calculateMeanStats = new window.statisticalCalculator(result, false, sliceStartValue, sliceEndValue, calculateStatsonComplete);
+        calculateMeanStats.getResults();
     }
 
     function downloadHttpOnProgress(result) {


### PR DESCRIPTION
We are currently performing the calculations for downloads on server which needs to be moved to client
Test: pull it down and run the test locally shouldn't see calculator call any more