### PR TITLE
Update xmlhttprequest timeout and percentage complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-testjs",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "measure internet bandwidth",
   "main": "index.js",
   "author": "Maulan Byron",

--- a/public/examples/download/downloadApp.js
+++ b/public/examples/download/downloadApp.js
@@ -178,7 +178,7 @@
         startTestButton.innerHTML = 'Testing in Progress ...';
         //disable button
         startTestButton.disabled = true;
-        //set accessiblity aria-disabled state. 
+        //set accessiblity aria-disabled state.
         //This will also effect the visual look by corresponding css
         startTestButton.setAttribute('aria-disabled', true);
     }
@@ -217,7 +217,7 @@
                 startTestButton.innerHTML = 'Start Test';
                 option.series[0].data[0].value = 0;
                 option.series[0].data[0].name = 'Test Complete';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
                 startTestButton.disabled = false;
@@ -248,14 +248,14 @@
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
                 option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
                //update button text to communicate current state of test as In Progress
                 startTestButton.innerHTML = 'Start Test';
                 //enable start button
                 startTestButton.disabled = false;
-                //hide current test value in chart 
+                //hide current test value in chart
                 option.series[0].detail.show = false;
                 //update gauge
                 myChart.setOption(option, true);
@@ -271,14 +271,14 @@
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
                 option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
                //update button text to communicate current state of test as In Progress
                 startTestButton.innerHTML = 'Start Test';
                 //enable start button
                 startTestButton.disabled = false;
-                //hide current test value in chart 
+                //hide current test value in chart
                 option.series[0].detail.show = false;
                 //update gauge
                 myChart.setOption(option, true);
@@ -294,17 +294,21 @@
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
                 option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
                //update button text to communicate current state of test as In Progress
                 startTestButton.innerHTML = 'Start Test';
                 //enable start button
                 startTestButton.disabled = false;
-                //hide current test value in chart 
+                //hide current test value in chart
                 option.series[0].detail.show = false;
                 //update gauge
                 myChart.setOption(option, true);
+        }
+
+        function downloadHttpOnPercentageComplete(result) {
+                 console.log(result);
         }
 
         urls.length = 0;
@@ -319,7 +323,7 @@
         }
 
         var downloadHttpConcurrentProgress = new window.downloadHttpConcurrentProgress(urls, 'GET', downloadCurrentRuns, downloadTestTimeout, downloadTestLength, downloadMovingAverage, downloadHttpOnComplete, downloadHttpOnProgress,
-            downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError, downloadSize, downloadProgressInterval, monitorInterval);
+            downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError, downloadSize, downloadProgressInterval, monitorInterval, downloadHttpOnPercentageComplete);
 
         downloadHttpConcurrentProgress.initiateTest();
     }

--- a/public/examples/download/downloadApp.js
+++ b/public/examples/download/downloadApp.js
@@ -307,10 +307,6 @@
                 myChart.setOption(option, true);
         }
 
-        function downloadHttpOnPercentageComplete(result) {
-                 console.log(result);
-        }
-
         urls.length = 0;
 
         var baseUrl = (version === 'IPv6') ? testPlan.baseUrlIPv6NoPort : testPlan.baseUrlIPv4NoPort;
@@ -323,7 +319,7 @@
         }
 
         var downloadHttpConcurrentProgress = new window.downloadHttpConcurrentProgress(urls, 'GET', downloadCurrentRuns, downloadTestTimeout, downloadTestLength, downloadMovingAverage, downloadHttpOnComplete, downloadHttpOnProgress,
-            downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError, downloadSize, downloadProgressInterval, monitorInterval, downloadHttpOnPercentageComplete);
+            downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError, downloadSize, downloadProgressInterval, monitorInterval);
 
         downloadHttpConcurrentProgress.initiateTest();
     }

--- a/public/examples/upload/uploadApp.js
+++ b/public/examples/upload/uploadApp.js
@@ -193,7 +193,7 @@
         startTestButton.innerHTML = 'Testing in Progress ...';
         //disable button
         startTestButton.disabled = true;
-        //set accessiblity aria-disabled state. 
+        //set accessiblity aria-disabled state.
         //This will also effect the visual look by corresponding css
         startTestButton.setAttribute('aria-disabled', true);
     }
@@ -257,17 +257,20 @@
                 option.series[0].data[0].value = 0;
                 //updat test status to complete
                 option.series[0].data[0].name = 'Test Failed';
-                //set accessiblity aria-disabled state. 
+                //set accessiblity aria-disabled state.
                 //This will also effect the visual look by corresponding css
                 startTestButton.setAttribute('aria-disabled', false);
                //update button text to communicate current state of test as In Progress
                 startTestButton.innerHTML = 'Start Test';
                 //enable start button
                 startTestButton.disabled = false;
-                //hide current test value in chart 
+                //hide current test value in chart
                 option.series[0].detail.show = false;
                 //update gauge
                 myChart.setOption(option, true);
+        }
+        function uploadHttpOnPercentageComplete(result) {
+                  console.log(result);
         }
 
         var uploadHttpConcurrentProgress;
@@ -283,7 +286,7 @@
         }
 
         uploadHttpConcurrentProgress = new window.uploadHttpConcurrentProgress(urls, 'POST', uploadCurrentRuns, uploadTestTimeout, uploadTestLength, uploadMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress,
-            uploadHttpOnError, uploadSize, testPlan.maxuploadSize, monitorInterval, isMicrosoftBrowser);
+            uploadHttpOnError, uploadSize, testPlan.maxuploadSize, monitorInterval, isMicrosoftBrowser, uploadHttpOnPercentageComplete);
 
         uploadHttpConcurrentProgress.initiateTest();
     }

--- a/public/examples/upload/uploadApp.js
+++ b/public/examples/upload/uploadApp.js
@@ -269,9 +269,6 @@
                 //update gauge
                 myChart.setOption(option, true);
         }
-        function uploadHttpOnPercentageComplete(result) {
-                  console.log(result);
-        }
 
         var uploadHttpConcurrentProgress;
         var baseUrl = (version === 'IPv6') ? testPlan.baseUrlIPv6NoPort : testPlan.baseUrlIPv4NoPort;
@@ -286,7 +283,7 @@
         }
 
         uploadHttpConcurrentProgress = new window.uploadHttpConcurrentProgress(urls, 'POST', uploadCurrentRuns, uploadTestTimeout, uploadTestLength, uploadMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress,
-            uploadHttpOnError, uploadSize, testPlan.maxuploadSize, monitorInterval, isMicrosoftBrowser, uploadHttpOnPercentageComplete);
+            uploadHttpOnError, uploadSize, testPlan.maxuploadSize, monitorInterval, isMicrosoftBrowser);
 
         uploadHttpConcurrentProgress.initiateTest();
     }

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -79,6 +79,7 @@
      * @return error object
      */
     downloadHttpConcurrentProgress.prototype.onTestError = function (result) {
+      console.dir(result);
       if (this._running) {
          if ((Date.now() - this._beginTime) > this.testLength) {
            this.endTest();
@@ -243,7 +244,7 @@
            this.clientCallbackError('no measurements obtained');
        }
        this.abortAll();
-     }
+     };
 
     /**
      * reset test variables

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -84,6 +84,12 @@
          if ((Date.now() - this._beginTime) > this.testLength) {
            this.endTest();
           }
+          else{
+            this._running = false;
+            clearInterval(this.interval);
+            this.clientCallbackError(result);
+            this.abortAll();
+          }
       }
     };
     /**

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -79,7 +79,6 @@
      * @return error object
      */
     downloadHttpConcurrentProgress.prototype.onTestError = function (result) {
-      console.dir(result);
       if (this._running) {
          if ((Date.now() - this._beginTime) > this.testLength) {
            this.endTest();

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -83,7 +83,7 @@
          console.log('onTestErrorCalled: ' + this.downloadResults.length);
          console.log('onTestErrorCalled call time: ' + (Date.now() - this._beginTime));
          if ((Date.now() - this._beginTime) > this.testLength) {
-           this.testEnd();
+           this.endTest();
           }
       }
     };
@@ -102,7 +102,7 @@
     downloadHttpConcurrentProgress.prototype.onTestTimeout = function () {
         if(this._running) {
             if ((Date.now() - this._beginTime) > this.testLength) {
-                this.testEnd();
+                this.endTest();
             }
 
         }

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -31,10 +31,9 @@
      * @param function callback function for test suite abort event
      * @param function callback function for test suite timeout event
      * @param function callback function for test suite error event
-     * @param function callback function for test percentage complete
      **/
     function downloadHttpConcurrentProgress(urls,  type, concurrentRuns, timeout, testLength, movingAverage, callbackComplete, callbackProgress, callbackAbort,
-                                            callbackTimeout, callbackError, size, progressIntervalDownload, monitorInterval, callbackPercentageComplete) {
+                                            callbackTimeout, callbackError, size, progressIntervalDownload, monitorInterval) {
         this.urls = urls;
         this.size = size;
         this.type = type;
@@ -55,7 +54,6 @@
         this.clientCallbackAbort = callbackAbort;
         this.clientCallbackTimeout = callbackTimeout;
         this.clientCallbackError = callbackError;
-        this.clientCallbackPercentageComplete = callbackPercentageComplete;
         //start time of test suite
         this._beginTime = Date.now();
         //boolean on whether test  suite is running or not
@@ -229,8 +227,6 @@
             }
 
         }
-        var percentComplete = Math.round(((Date.now() - this._beginTime)/this.testLength)*100);
-        this.clientCallbackPercentageComplete(percentComplete);
         //check for end of test
         if ((Date.now() - this._beginTime) > this.testLength) {
           this.endTest();

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -80,8 +80,6 @@
      */
     downloadHttpConcurrentProgress.prototype.onTestError = function (result) {
       if (this._running) {
-         console.log('onTestErrorCalled: ' + this.downloadResults.length);
-         console.log('onTestErrorCalled call time: ' + (Date.now() - this._beginTime));
          if ((Date.now() - this._beginTime) > this.testLength) {
            this.endTest();
           }
@@ -102,7 +100,6 @@
     downloadHttpConcurrentProgress.prototype.onTestTimeout = function () {
         if(this._running) {
             if ((Date.now() - this._beginTime) > this.testLength) {
-              console.log('call endTest onTestTimeout');
                 this.endTest();
             }
 
@@ -134,7 +131,6 @@
         }
         //check for end of test
         if ((Date.now() - this._beginTime) > this.testLength) {
-          console.log('call endTest onTestProgress');
             this.endTest();
         }
         this.totalBytes = this.totalBytes + result.loaded;
@@ -170,7 +166,6 @@
         clearInterval(this.interval);
         for (var i = 0; i < this._activeTests.length; i++) {
             if (typeof(this._activeTests[i]) !== 'undefined') {
-              console.log('abort request');
                 this._activeTests[i].xhr._request.abort();
             }
         }
@@ -232,7 +227,6 @@
         this.clientCallbackPercentageComplete(percentComplete);
         //check for end of test
         if ((Date.now() - this._beginTime) > this.testLength) {
-          console.log('call endTest onMonitor');
           this.endTest();
         }
 

--- a/public/lib/downloadHttpConcurrentProgress.js
+++ b/public/lib/downloadHttpConcurrentProgress.js
@@ -102,6 +102,7 @@
     downloadHttpConcurrentProgress.prototype.onTestTimeout = function () {
         if(this._running) {
             if ((Date.now() - this._beginTime) > this.testLength) {
+              console.log('call endTest onTestTimeout');
                 this.endTest();
             }
 
@@ -133,6 +134,7 @@
         }
         //check for end of test
         if ((Date.now() - this._beginTime) > this.testLength) {
+          console.log('call endTest onTestProgress');
             this.endTest();
         }
         this.totalBytes = this.totalBytes + result.loaded;
@@ -168,6 +170,7 @@
         clearInterval(this.interval);
         for (var i = 0; i < this._activeTests.length; i++) {
             if (typeof(this._activeTests[i]) !== 'undefined') {
+              console.log('abort request');
                 this._activeTests[i].xhr._request.abort();
             }
         }
@@ -229,6 +232,7 @@
         this.clientCallbackPercentageComplete(percentComplete);
         //check for end of test
         if ((Date.now() - this._beginTime) > this.testLength) {
+          console.log('call endTest onMonitor');
           this.endTest();
         }
 

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -87,7 +87,6 @@
      * @return error object
      */
     uploadHttpConcurrentProgress.prototype.onTestError = function (result) {
-      console.dir(result);
         if (this._running) {
           if ((Date.now() - this._beginTime) > this.testLength) {
             this.endTest();

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -89,7 +89,7 @@
     uploadHttpConcurrentProgress.prototype.onTestError = function (result) {
         if (this._running) {
           if ((Date.now() - this._beginTime) > this.testLength) {
-            this.testEnd();
+            this.endTest();
           }
         }
     };
@@ -108,7 +108,7 @@
     uploadHttpConcurrentProgress.prototype.onTestTimeout = function () {
         if (this._running) {
             if ((Date.now() - this._beginTime) > this.testLength) {
-              this.testEnd();
+              this.endTest();
             }
 
         }
@@ -276,7 +276,7 @@
     /**
      * end of test
      */
-    uploadHttpConcurrentProgress.prototype.testEnd = function () {
+    uploadHttpConcurrentProgress.prototype.endTest = function () {
       this._running = false;
       this.abortAll();
       clearInterval(this.interval);
@@ -300,7 +300,7 @@
         var percentComplete = Math.round(((Date.now() - this._beginTime)/this.testLength)*100);
         this.clientCallbackPercentageComplete(percentComplete);
         if ((Date.now() - this._beginTime) > this.testLength) {
-          this.testEnd();
+          this.endTest();
         }
     };
 

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -34,10 +34,9 @@
      * @param size - initial size to start upload testing.
      * @param maxuploadSize - upload size should not exceed max upload size.
      * @param monitorInterval - monitor interval.
-     * @param function callback function for test percentage complete
      */
     function uploadHttpConcurrentProgress(urls, type, concurrentRuns, timeout, testLength, movingAverage, callbackComplete, callbackProgress, callbackError, size, maxuploadSize,
-                                          monitorInterval, isMicrosoftBrowser, callbackPercentageComplete) {
+                                          monitorInterval, isMicrosoftBrowser) {
         this.urls = urls;
         this.size = size;
         this.type = type;
@@ -54,7 +53,6 @@
         this.clientCallbackComplete = callbackComplete;
         this.clientCallbackProgress = callbackProgress;
         this.clientCallbackError = callbackError;
-        this.clientCallbackPercentageComplete = callbackPercentageComplete;
         //start time of test suite
         this._beginTime = Date.now();
         //boolean on whether test  suite is running or not
@@ -303,8 +301,6 @@
     uploadHttpConcurrentProgress.prototype._monitor = function () {
         this._calculateResults();
         //check for end of test
-        var percentComplete = Math.round(((Date.now() - this._beginTime)/this.testLength)*100);
-        this.clientCallbackPercentageComplete(percentComplete);
         if ((Date.now() - this._beginTime) > this.testLength) {
           this.endTest();
         }

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -87,6 +87,7 @@
      * @return error object
      */
     uploadHttpConcurrentProgress.prototype.onTestError = function (result) {
+      console.dir(result);
         if (this._running) {
           if ((Date.now() - this._beginTime) > this.testLength) {
             this.endTest();
@@ -290,7 +291,7 @@
       } else {
           this.clientCallbackError('no measurements obtained');
       }
-    }
+    };
     /**
      * Monitor testSeries
      */

--- a/public/lib/uploadHttpConcurrentProgress.js
+++ b/public/lib/uploadHttpConcurrentProgress.js
@@ -92,6 +92,12 @@
           if ((Date.now() - this._beginTime) > this.testLength) {
             this.endTest();
           }
+          else{
+            this._running = false;
+            clearInterval(this.interval);
+            this.clientCallbackError(result);
+            this.abortAll();
+          }
         }
     };
     /**

--- a/public/lib/xmlhttprequest.js
+++ b/public/lib/xmlhttprequest.js
@@ -98,9 +98,6 @@
   * internal timed abort
   */
   xmlHttpRequest.prototype._internalAbort = function() {
-    console.log('internal abort');
-    console.log(this.id);
-    console.dir(this._request);
     if((this._request)&&(this._request.readyState!==4)){
       this._request.abort();
     }
@@ -115,9 +112,7 @@
   /**
   * Handle eror event
   */
-  xmlHttpRequest.prototype._handleError = function(response) {
-    console.log('xmlHttpRequest Error');
-    console.dir(response);
+  xmlHttpRequest.prototype._handleError = function() {
     clearTimeout(this.requestTimeout);
      var err = {
        statusText: this._request.statusText,
@@ -129,7 +124,6 @@
       * Handle the timeout event on the wrapped request
       */
      xmlHttpRequest.prototype._handleTimeout = function(response) {
-       console.log('xmlHttpRequest timeOut');
        clearTimeout(this.requestTimeout);
        this.totalTime = this.endTime - this.startTime;
        var transferSizeMbs = (response.loaded * 8) / 1000000;
@@ -145,7 +139,6 @@
       * Handle the abort event on the wrapped request
       */
      xmlHttpRequest.prototype._handleAbort = function(response) {
-       console.log('xmlHttpRequest _handleAbort');
        clearTimeout(this.requestTimeout);
        this.totalTime = Date.now() - this.startTime;
        var transferSizeMbs = (response.loaded * 8) / 1000000;
@@ -167,7 +160,6 @@
     * Close the request explicitly
     */
   xmlHttpRequest.prototype.close = function () {
-    console.log('xmlHttpRequest close method');
     clearTimeout(this.requestTimeout);
     if((this._request)&&(this._request.readyState!==4)){
       this._request.abort();

--- a/public/lib/xmlhttprequest.js
+++ b/public/lib/xmlhttprequest.js
@@ -176,14 +176,6 @@
               }
 
           }
-    if(this._request.status > 399){
-      var err = {
-        statusText: this._request.statusText,
-        status: this._request.status
-      };
-      this.callbackError(err);
-      return;
-    }
   };
 
   /**

--- a/public/lib/xmlhttprequest.js
+++ b/public/lib/xmlhttprequest.js
@@ -100,7 +100,8 @@
     if((this._request)&&(this._request.readyState!==4)){
       this._request.abort();
     }
-  }
+  };
+  
   /**
   * Mark the start time of the request
   */

--- a/public/lib/xmlhttprequest.js
+++ b/public/lib/xmlhttprequest.js
@@ -83,7 +83,6 @@
       this.id = id;
       this.transferSize = size;
       this._request.open(this.method, this.url, true);
-      this._request.timeout = this.timeout;
       this.requestTimeout= setTimeout(this._internalAbort.bind(this), this.timeout);
       if(this.method==='POST') {
         this._request.send(payload);

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -450,10 +450,6 @@
       myChart.setOption(option, true);
     }
 
-    function downloadHttpOnPercentageComplete(result) {
-        console.log(result);
-    }
-
     downloadUrls.length=0;
     var baseUrl = (version === 'IPv6') ? testPlan.baseUrlIPv6NoPort : testPlan.baseUrlIPv4NoPort;
     for (var i = 0; i < ports.length; i++) {
@@ -464,7 +460,7 @@
       }
     }
     var downloadHttpConcurrentProgress = new window.downloadHttpConcurrentProgress(downloadUrls, 'GET', downloadCurrentRuns, downloadTestTimeout, downloadTestLength, downloadMovingAverage, downloadHttpOnComplete, downloadHttpOnProgress,
-      downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError,downloadSize, downloadProgressInterval,downloadMonitorInterval, downloadHttpOnPercentageComplete);
+      downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError,downloadSize, downloadProgressInterval,downloadMonitorInterval);
 
     downloadHttpConcurrentProgress.initiateTest();
   }
@@ -537,12 +533,8 @@
           }
       }
 
-      function uploadHttpOnPercentageComplete(result) {
-          console.log(result);
-      }
-
       var uploadHttpConcurrentProgress = new window.uploadHttpConcurrentProgress(uploadUrls, 'POST', uploadCurrentRuns, uploadTestTimeout, uploadTestLength, uploadMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress,
-          uploadHttpOnError, uploadSize, testPlan.maxuploadSize, uploadMonitorInterval, isMicrosoftBrowser, uploadHttpOnPercentageComplete);
+          uploadHttpOnError, uploadSize, testPlan.maxuploadSize, uploadMonitorInterval, isMicrosoftBrowser);
 
       uploadHttpConcurrentProgress.initiateTest();
   }

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -166,8 +166,6 @@
       if (xhr.readyState == XMLHttpRequest.DONE) {
         var data = JSON.parse(xhr.responseText);
         testPlan = data;
-        testPlan.hasIPv6 = false;
-        testPlan.baseUrlIPv4NoPort = '127.0.0.1';
         if (testPlan.performLatencyRouting) {
           latencyBasedRouting();
         }

--- a/public/speed-testJS.js
+++ b/public/speed-testJS.js
@@ -166,6 +166,8 @@
       if (xhr.readyState == XMLHttpRequest.DONE) {
         var data = JSON.parse(xhr.responseText);
         testPlan = data;
+        testPlan.hasIPv6 = false;
+        testPlan.baseUrlIPv4NoPort = '127.0.0.1';
         if (testPlan.performLatencyRouting) {
           latencyBasedRouting();
         }
@@ -450,6 +452,10 @@
       myChart.setOption(option, true);
     }
 
+    function downloadHttpOnPercentageComplete(result) {
+        console.log(result);
+    }
+
     downloadUrls.length=0;
     var baseUrl = (version === 'IPv6') ? testPlan.baseUrlIPv6NoPort : testPlan.baseUrlIPv4NoPort;
     for (var i = 0; i < ports.length; i++) {
@@ -460,7 +466,7 @@
       }
     }
     var downloadHttpConcurrentProgress = new window.downloadHttpConcurrentProgress(downloadUrls, 'GET', downloadCurrentRuns, downloadTestTimeout, downloadTestLength, downloadMovingAverage, downloadHttpOnComplete, downloadHttpOnProgress,
-      downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError,downloadSize, downloadProgressInterval,downloadMonitorInterval);
+      downloadHttpOnAbort, downloadHttpOnTimeout, downloadHttpOnError,downloadSize, downloadProgressInterval,downloadMonitorInterval, downloadHttpOnPercentageComplete);
 
     downloadHttpConcurrentProgress.initiateTest();
   }
@@ -533,8 +539,12 @@
           }
       }
 
+      function uploadHttpOnPercentageComplete(result) {
+          console.log(result);
+      }
+
       var uploadHttpConcurrentProgress = new window.uploadHttpConcurrentProgress(uploadUrls, 'POST', uploadCurrentRuns, uploadTestTimeout, uploadTestLength, uploadMovingAverage, uploadHttpOnComplete, uploadHttpOnProgress,
-          uploadHttpOnError, uploadSize, testPlan.maxuploadSize, uploadMonitorInterval, isMicrosoftBrowser);
+          uploadHttpOnError, uploadSize, testPlan.maxuploadSize, uploadMonitorInterval, isMicrosoftBrowser, uploadHttpOnPercentageComplete);
 
       uploadHttpConcurrentProgress.initiateTest();
   }


### PR DESCRIPTION
Why: Edge 15 is periodically throwing error at the end of testing due to timing issue and need to report percentage complete to client
How: Update timing logic to remove error and return percentage complete
Test: check locally and run in edge 15 and verify test completes with no error