### PR TITLE
Update as per npm audit fix and  mem issue for download fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target/
 dist.tar.gz
 dist
 public/docs
+package-lock.json

--- a/controllers/DownloadController.js
+++ b/controllers/DownloadController.js
@@ -53,8 +53,7 @@ class DownloadController {
       if(!isNaN(parseInt(req.query.bufferSize))  && (parseInt(req.query.bufferSize)<=global.maxDownloadBuffer) &&(parseInt(req.query.bufferSize)>0)){
         var bufferStream = new stream.PassThrough();
         bufferStream.pipe(res);
-        var responseBuffer = new Buffer(parseInt(req.query.bufferSize));
-        responseBuffer.fill(0x1020304);
+        var responseBuffer = global.maxBuffer.slice(0, parseInt(req.query.bufferSize))
         bufferStream.write(responseBuffer);
         bufferStream.end();
       }

--- a/index.js
+++ b/index.js
@@ -95,7 +95,9 @@ app.listen(5023);
 app.listen(5024);
 app.listen(5025);
 //max download buffer size based off of download probing data
-global.maxDownloadBuffer = 532421875;
+global.maxDownloadBuffer = 532421875
+global.maxBuffer=Buffer.allocUnsafe(global.maxDownloadBuffer).fill(0x1020304)
+
 global.maxUploadBuffer = 10000000;
 
 var wss = new WebSocketServer({port: webSocketPort});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-docco-multi": "0.0.4",
     "grunt-tar.gz": "0.0.6",
     "jasmine": "^2.5.2",
-    "karma": "^1.3.0",
+    "karma": "^3.1.4",
     "karma-jasmine": "^1.0.2",
     "karma-requirejs": "^1.1.0"
   },


### PR DESCRIPTION
updated for new nodejs version Buffer warning
(node:26547) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.